### PR TITLE
fixed bytes[] decode error

### DIFF
--- a/lib/solidity/type.js
+++ b/lib/solidity/type.js
@@ -213,7 +213,9 @@ SolidityType.prototype.decode = function (bytes, offset, name) {
             var result = [];
 
             for (var i = 0; i < length * roundedNestedStaticPartLength; i += roundedNestedStaticPartLength) {
-                result.push(self.decode(bytes, arrayStart + i, nestedName));
+                //result.push(self.decode(bytes, arrayStart + i, nestedName));
+                //ABI use only relative address. update the bytes with every recursive call
+                result.push(self.decode(bytes.substr(arryStart * 2), i, nestedName));
             }
 
             return result;


### PR DESCRIPTION
Based on the rule --The data of a variable or array element is not interleaved with other data and it is relocatable, i.e. it only uses relative “addresses”. The bytes should be updated with every recursive call instead of passing the complete raw input everytime